### PR TITLE
Specify a default author

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,8 @@ theme = "lightspeed"
 
 title = "JP's Website"
 
+author = "Jonathan 'theJPster' Pallant"
+
 taxonomies = [
     # You can enable/disable RSS
     {name = "categories", rss = true},


### PR DESCRIPTION
Set the author in config.toml. This means the atom.xml RSS feed no longer marks the author as 'Unknown'.

Closes #27