### PR TITLE
Yet more retrofest details

### DIFF
--- a/static/retrofest/machines/index.html
+++ b/static/retrofest/machines/index.html
@@ -121,6 +121,10 @@
     <dd>4 GB SCSI-2</dd>
     <dt>Graphics</dt>
     <dd>Silicon Graphics XZ</dd>
+    <dt>3D Graphics Performance (shaded)</dt>
+    <dd>37 Mpx/sec (PlayStation gets 33 Mpx/sec)</dd>
+    <dt>3D Graphics Performance (textured)</dt>
+    <dd>N/A</dd>
     <dt>Keyboard/Mouse</dt>
     <dd>Standard PC-compatible PS/2 interface</dd>
     <dt>OS</dt>
@@ -180,7 +184,9 @@
     <dt>Hard Drive Fitted</dt>
     <dd>18 GB Ultra Wide SCSI</dd>
     <dt>Graphics</dt>
-    <dd>Integrated</dd>
+    <dd>Integrated Visualize-EG (2 MB)</dd>
+    <dt>3D Graphics Performance</dt>
+    <dd>N/A</dd>
     <dt>Keyboard/Mouse</dt>
     <dd>Standard PC-compatible PS/2 interface</dd>
     <dt>OS</dt>
@@ -234,7 +240,11 @@
     <dt>Hard Drive Fitted</dt>
     <dd>9 GB Ultra Wide SCSI</dd>
     <dt>Graphics</dt>
-    <dd>HP Visualize FX5Pro</dd>
+    <dd>Visualize FX5Pro (64 MB)</dd>
+    <dt>3D Graphics Performance (shaded)</dt>
+    <dd>179 Mpx/sec (NVIDIA Quadro gets 465 Mpx/sec)</dd>
+    <dt>3D Graphics Performance (textured)</dt>
+    <dd>167 Mpx/sec (NVIDIA Quadro gets 199 Mpx/sec)</dd>
     <dt>Keyboard/Mouse</dt>
     <dd>USB</dd>
     <dt>OS</dt>
@@ -297,7 +307,9 @@
     <dt>Hard Drive Fitted</dt>
     <dd>9 GB Ultra Wide SCSI</dd>
     <dt>Graphics</dt>
-    <dd>Sun PGX32 (2D only)</dd>
+    <dd>Sun PGX32 (8 MB)</dd>
+    <dt>3D Graphics Performance</dt>
+    <dd>N/A</dd>
     <dt>Keyboard/Mouse</dt>
     <dd>Sun proprietary bus</dd>
     <dt>OS</dt>

--- a/static/retrofest/machines/index.html
+++ b/static/retrofest/machines/index.html
@@ -71,6 +71,11 @@
     Cray in 1996.
 </p>
 <p>
+    Naturally, computers have moved on somewhat in the last ~30 years, and the
+    R8000 is out-performed (but not outclassed) by the ARM11 CPU you get on a
+    $10 Raspberry Pi Zero.
+</p>
+<p>
     The Indigo 2 was, for a short time and at an extraordinary price tag,
     available with a single instance of this the super-computer grade CPU. An
     R8000-equipped Indigo 2 is known in the marketing material as a "POWER
@@ -94,8 +99,9 @@
     also still a steep discount on the original list price of $75,000.
 </p>
 <p>
-    Naturally, computers have moved on somewhat in the last ~30 years, and the
-    R8000 is out-classed by the ARM11 CPU you get on a $10 Raspberry Pi Zero.
+    I have no information about the history of this particular example, other
+    than I acquired it from a lovely person called Kestral who I met on social
+    media.
 </p>
 <p>
     This POWER Indigo 2 is running IRIX 6.2 from 1996, which is a little bit
@@ -150,7 +156,12 @@
     powerhouse. It has six 72-pin SIMM slots and takes ECC RAM.
 </p>
 <p>
-    This machine is running HP-UX 10.20 from 1996, which is probably what our
+    This example was actually a server for Cable and Wireless and only came out
+    of service recently. The video output has a 'VESA EVC' and the vendor
+    thankfully included a VGA adapter.</p>
+</p>
+<p>
+    It is running HP-UX 10.20 from 1996, which is probably what our
     machine should have shipped with. HP-UX 10.20 came with both <a
     href="../desktops/index.html#vue">VUE</a> and its replacement <a
     href="../desktops/index.html#cde">CDE</a>. I've elected to install the
@@ -201,10 +212,15 @@
     <img src="c3000_inside.gif" alt="The CPU and RAM in this C3000">
 </p>
 <p>
-    This machine is running HP-UX 11.00 from 1996, which is probably what our
-    machine should have shipped with and is the first 64-bit version of HP-UX.
-    HP-UX 11.00 came with only the <a href="../desktops/index.html#cde">Common
-    Desktop Environment (CDE)</a>.
+    This example was actually a server for Virgin Media and only came out of
+    service recently. A 3D graphics card was added by the vendor so I wouldn't
+    be forced to use the serial console.</p>
+</p>
+<p>
+    It is running HP-UX 11.00 from 1996, which is probably what our machine
+    should have shipped with and is the first 64-bit version of HP-UX. HP-UX
+    11.00 came with only the <a href="../desktops/index.html#cde">Common Desktop
+    Environment (CDE)</a>.
 </p>
 <dl>
     <dt>Processor</dt>
@@ -255,6 +271,12 @@
 </p>
 <p>
     <img src="ultra80_inside.gif" alt="The insides of an Ultra 80">
+</p>
+<p>
+    This example is fitted with a 2D graphics card, and the stickers on the case
+    indicate it came from Oxford University Computing Laboratory. I like to
+    think it was used for C programming and maybe some mathematical modelling in
+    MATLAB.
 </p>
 <p>
     This machine would have shipped with Sun Solaris 7, which was the first


### PR DESCRIPTION
Added a bit of history and some 3D graphics performance. Now you know the POWER Indigo 2 has the fill-rate of a PlayStation (roughly), whilst the C3000 is not as good as an NVIDIA Quadro.